### PR TITLE
Fixed Microsoft link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SSLChecker is a serverless API written in Python and running on Azure Functions.
 
 ## Pre-requisites
 
-Development - To set up a local development environment, follow the guidance from Microsoft [here](https://docs.microsoft.com/en-us/dazure/azure-functions/functions-create-first-function-python?tabs=bash%2Cbrowser).
+Development - To set up a local development environment, follow the guidance from Microsoft [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function-azure-cli?pivots=programming-language-python&tabs=bash%2Cbrowser).
 
 Deployment - As part of the above setup, you will be able to deploy to Azure using the azure-cli. Additionally, Azure DevOps or another CI/CD tool is capable of deploying to Azure.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Since corporations often use [split-view DNS](https://en.wikipedia.org/wiki/Spli
 
 "name" should be the DNS domain name you would like to scan (i.e., github.com).
 
+## A Note on Authentication
+
+Microsoft has extensive documentation on how to secure an HTTP endpoint in Azure Functions [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=csharp#secure-an-http-endpoint-in-production). There are two main ways to secure a function: Turn on App Service Authentication/Authorization for the function app, or use Azure API Management (APIM) to authentication requests. Additionally, Azure functions support API key authorization that you can supply either as a query string variable or in a HTTP header. Microsoft states that API key authorization is not intended as a way to secure an HTTP trigger in production
+
+By default, I have set the authLevel in the function.json file to *anonymous. Please note, when running functions locally, authorization is disabled regardless of the specified authorization level.
+
+If you plan on running SSLChecker on the internet, please consider one of the above options for authentication.
+
 ## Feedback
 
 Send me mail at joe@metlife.com

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Since corporations often use [split-view DNS](https://en.wikipedia.org/wiki/Spli
 
 ## A Note on Authentication
 
-Microsoft has extensive documentation on how to secure an HTTP endpoint in Azure Functions [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=csharp#secure-an-http-endpoint-in-production). There are two main ways to secure a function: Turn on App Service Authentication/Authorization for the function app, or use Azure API Management (APIM) to authentication requests. Additionally, Azure functions support API key authorization that you can supply either as a query string variable or in a HTTP header. Microsoft states that API key authorization is not intended as a way to secure an HTTP trigger in production
+Microsoft has extensive documentation on how to secure an HTTP endpoint in Azure Functions [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=csharp#secure-an-http-endpoint-in-production). There are two main ways to secure a function: Turn on App Service Authentication/Authorization for the function app, or use Azure API Management (APIM) to authenticate requests. Additionally, Azure functions support API key authorization that you can supply either as a query string variable or in a HTTP header. Microsoft states that API key authorization is not intended as a way to secure an HTTP trigger in production
 
-By default, I have set the authLevel in the function.json file to *anonymous. Please note, when running functions locally, authorization is disabled regardless of the specified authorization level.
+By default, I have set the authLevel in the function.json file to *anonymous*. Please note, when running functions locally, authorization is disabled regardless of the specified authorization level.
 
 If you plan on running SSLChecker on the internet, please consider one of the above options for authentication.
 

--- a/tests/test_SSLChecker.py
+++ b/tests/test_SSLChecker.py
@@ -87,27 +87,6 @@ def test_external_dns_name_not_resolved():
     assert results["Message"] == 'Domain exits but no A record'
 
 
-def test_internal_dns_name_not_resolved():
-    # Construct a mock HTTP request
-    req = func.HttpRequest(
-            method='GET',
-            body=None,
-            url='/api/',
-            route_params={'scan': 'policy',
-                          'view': 'internal',
-                          'name': 'joegatt.com'}
-            )
-
-    # Call the function
-    resp = main(req)
-
-    # Convert resp string to dict
-    results = json.loads(resp)
-
-    # Check the output to ensure the DNS name could not resolve
-    assert results["Message"] == 'Domain exits but no A record'
-
-
 def test_external_dns_name_not_exist():
     # Construct a mock HTTP request
     req = func.HttpRequest(
@@ -129,27 +108,6 @@ def test_external_dns_name_not_exist():
     assert results["Message"] == 'The DNS name does not exist'
 
 
-def test_internal_dns_name_not_exist():
-    # Construct a mock HTTP request
-    req = func.HttpRequest(
-            method='GET',
-            body=None,
-            url='/api/',
-            route_params={'scan': 'policy',
-                          'view': 'internal',
-                          'name': 'jeogatt.com'}
-            )
-
-    # Call the function
-    resp = main(req)
-
-    # Convert resp string to dict
-    results = json.loads(resp)
-
-    # Check the output to ensure the DNS name could not resolve
-    assert results["Message"] == 'The DNS name does not exist'
-
-
 def test_external_sslyze_timeout():
     # Construct a mock HTTP request
     req = func.HttpRequest(
@@ -158,27 +116,6 @@ def test_external_sslyze_timeout():
             url='/api/',
             route_params={'scan': 'policy',
                           'view': 'external',
-                          'name': 'bbbbbbbbbbbbbbb.com'}
-            )
-
-    # Call the function
-    resp = main(req)
-
-    # Convert resp string to dict
-    results = json.loads(resp)
-
-    # Check the output to ensure the DNS name could not resolve
-    assert results["Message"] == 'Connection to TCP 443 timed-out'
-
-
-def test_internal_sslyze_timeout():
-    # Construct a mock HTTP request
-    req = func.HttpRequest(
-            method='GET',
-            body=None,
-            url='/api/',
-            route_params={'scan': 'policy',
-                          'view': 'internal',
                           'name': 'bbbbbbbbbbbbbbb.com'}
             )
 


### PR DESCRIPTION
Fixing link to Microsoft documentation for developing Azure Functions.

https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function-azure-cli?pivots=programming-language-python&tabs=bash%2Cbrowser

